### PR TITLE
Hacks to compare IWRR and EDF

### DIFF
--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -125,8 +125,11 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "edf_scheduler_lib",
-    hdrs = ["edf_scheduler.h", "iwrr_scheduler.h"],
-    deps = ["//source/common/common:assert_lib"],
+    hdrs = ["edf_scheduler.h", "iwrr_scheduler.h", "wrsq_scheduler.h"],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//include/envoy/common:random_generator_interface",
+    ],
 )
 
 envoy_cc_library(
@@ -178,6 +181,7 @@ envoy_cc_library(
         "//include/envoy/common:random_generator_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/stats:stats_interface",
+        "//source/common/common:random_generator_lib",
         "//include/envoy/upstream:load_balancer_interface",
         "//include/envoy/upstream:upstream_interface",
         "//source/common/common:assert_lib",

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -125,7 +125,7 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "edf_scheduler_lib",
-    hdrs = ["edf_scheduler.h"],
+    hdrs = ["edf_scheduler.h", "iwrr_scheduler.h"],
     deps = ["//source/common/common:assert_lib"],
 )
 

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -18,12 +18,26 @@ namespace Upstream {
 #define EDF_TRACE(...)
 #endif
 
+/**
+ * A hack to illustrate a point.
+ */
+template <class C>
+class Scheduler {
+public:
+  virtual ~Scheduler() {}
+  virtual std::shared_ptr<C> peekAgain(std::function<double(const C&)> calculate_weight) = 0;
+  virtual std::shared_ptr<C> pickAndAdd(std::function<double(const C&)> calculate_weight) = 0;
+  virtual void add(double weight, std::shared_ptr<C> entry) = 0;
+  virtual bool empty() const = 0;
+};
+
+
 // Earliest Deadline First (EDF) scheduler
 // (https://en.wikipedia.org/wiki/Earliest_deadline_first_scheduling) used for weighted round robin.
 // Each pick from the schedule has the earliest deadline entry selected. Entries have deadlines set
 // at current time + 1 / weight, providing weighted round robin behavior with floating point
 // weights and an O(log n) pick time.
-template <class C> class EdfScheduler {
+template <class C> class EdfScheduler : public Scheduler<C> {
 public:
   // Each time peekAgain is called, it will return the best-effort subsequent
   // pick, popping and reinserting the entry as if it had been picked, and
@@ -32,7 +46,7 @@ public:
   // first item which will be picked, the second time it is called it will
   // return the second item which will be picked. As picks occur, that window
   // will shrink.
-  std::shared_ptr<C> peekAgain(std::function<double(const C&)> calculate_weight) {
+  std::shared_ptr<C> peekAgain(std::function<double(const C&)> calculate_weight) override {
     if (hasEntry()) {
       prepick_list_.push_back(std::move(queue_.top().entry_));
       std::shared_ptr<C> ret{prepick_list_.back()};
@@ -48,10 +62,13 @@ public:
    *   from calculate_weight.
    * @return std::shared_ptr<C> to next valid the queue entry if or nullptr if none exists.
    */
-  std::shared_ptr<C> pickAndAdd(std::function<double(const C&)> calculate_weight) {
+  std::shared_ptr<C> pickAndAdd(std::function<double(const C&)> calculate_weight) override {
+//    std::cout << "pick and add\n";
     while (!prepick_list_.empty()) {
+      //std::cout << "prepick list not empty\n";
       // In this case the entry was added back during peekAgain so don't re-add.
       if (prepick_list_.front().expired()) {
+        ////std::cout << "front expired\n";
         prepick_list_.pop_front();
         continue;
       }
@@ -60,6 +77,7 @@ public:
       return ret;
     }
     if (hasEntry()) {
+      //std::cout << "has entry\n";
       std::shared_ptr<C> ret{queue_.top().entry_};
       queue_.pop();
       add(calculate_weight(*ret), ret);
@@ -73,11 +91,10 @@ public:
    * @param weight floating point weight.
    * @param entry shared pointer to entry, only a weak reference will be retained.
    */
-  void add(double weight, std::shared_ptr<C> entry) {
+  void add(double weight, std::shared_ptr<C> entry) override {
     ASSERT(weight > 0);
     const double deadline = current_time_ + 1.0 / weight;
-    EDF_TRACE("Insertion {} in queue with deadline {} and weight {}.",
-              static_cast<const void*>(entry.get()), deadline, weight);
+    //std::cout << "Insertion " << static_cast<const void*>(entry.get()) << " in queue with deadline " << deadline << " and weight " << weight << "\n";
     queue_.push({deadline, order_offset_++, entry});
     ASSERT(queue_.top().deadline_ >= current_time_);
   }
@@ -86,30 +103,30 @@ public:
    * Implements empty() on the internal queue. Does not attempt to discard expired elements.
    * @return bool whether or not the internal queue is empty.
    */
-  bool empty() const { return queue_.empty(); }
+  bool empty() const override { return queue_.empty(); }
 
 private:
   /**
    * Clears expired entries, and returns true if there's still entries in the queue.
    */
   bool hasEntry() {
-    EDF_TRACE("Queue pick: queue_.size()={}, current_time_={}.", queue_.size(), current_time_);
+    //std::cout << "Queue pick: queue_.size()=" << queue_.size() << ", current_time_=" << current_time_ << "\n";
     while (true) {
       if (queue_.empty()) {
-        EDF_TRACE("Queue is empty.");
+        //std::cout << "Queue is empty.\n";
         return false;
       }
       const EdfEntry& edf_entry = queue_.top();
       // Entry has been removed, let's see if there's another one.
       if (edf_entry.entry_.expired()) {
-        EDF_TRACE("Entry has expired, repick.");
+        //std::cout << "Entry has expired, repick.\n";
         queue_.pop();
         continue;
       }
       std::shared_ptr<C> ret{edf_entry.entry_};
       ASSERT(edf_entry.deadline_ >= current_time_);
       current_time_ = edf_entry.deadline_;
-      EDF_TRACE("Picked {}, current_time_={}.", static_cast<const void*>(ret.get()), current_time_);
+      //std::cout << "Picked " << *ret << ", current_time_=" <<  current_time_ << "\n";
       return true;
     }
   }

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -22,9 +22,9 @@ namespace Upstream {
  * A hack to illustrate a point.
  */
 template <class C>
-class Scheduler {
+class RRScheduler {
 public:
-  virtual ~Scheduler() {}
+  virtual ~RRScheduler() {}
   virtual std::shared_ptr<C> peekAgain(std::function<double(const C&)> calculate_weight) = 0;
   virtual std::shared_ptr<C> pickAndAdd(std::function<double(const C&)> calculate_weight) = 0;
   virtual void add(double weight, std::shared_ptr<C> entry) = 0;
@@ -37,7 +37,7 @@ public:
 // Each pick from the schedule has the earliest deadline entry selected. Entries have deadlines set
 // at current time + 1 / weight, providing weighted round robin behavior with floating point
 // weights and an O(log n) pick time.
-template <class C> class EdfScheduler : public Scheduler<C> {
+template <class C> class EdfScheduler : public RRScheduler<C> {
 public:
   // Each time peekAgain is called, it will return the best-effort subsequent
   // pick, popping and reinserting the entry as if it had been picked, and

--- a/source/common/upstream/iwrr_scheduler.h
+++ b/source/common/upstream/iwrr_scheduler.h
@@ -1,0 +1,57 @@
+#include <algorithm>
+#include <memory>
+#include <iostream>
+
+#include "common/upstream/edf_scheduler.h"
+
+namespace Envoy {
+namespace Upstream {
+namespace {
+
+/**
+ * IWRR scheduler.
+ */
+template <class C>
+class IWRRScheduler : public Scheduler<C> {
+ public:
+  std::shared_ptr<C> peekAgain(std::function<double(const C&)> ) override {
+    // not using this now
+    return std::shared_ptr<C>();
+  }
+
+  std::shared_ptr<C> pickAndAdd(std::function<double(const C&)> ) override {
+    if (curr_weights_.empty()) {
+      curr_weights_ = weights_;
+    }
+
+    auto ret = std::move(curr_weights_.front());
+    curr_weights_.pop();
+    --ret.second;
+    if (ret.second > 0) {
+      curr_weights_.emplace(ret);
+    }
+
+    return ret.first;
+  }
+
+  void add(double weight, std::shared_ptr<C> entry) override {
+    curr_weights_.emplace(entry, weight);
+    weights_.emplace(entry, weight);
+  }
+
+  bool empty() const override {
+    return weights_.empty();
+  }
+
+ private:
+  // TODO do the swap thing
+  std::queue<std::pair<std::shared_ptr<C>, double>> curr_weights_;
+
+  std::queue<std::pair<std::shared_ptr<C>, double>> weights_;
+};
+
+} // namespace
+} // namespace Upstream
+} // namespace Envoy
+
+

--- a/source/common/upstream/iwrr_scheduler.h
+++ b/source/common/upstream/iwrr_scheduler.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <algorithm>
 #include <memory>
 #include <iostream>
@@ -12,7 +14,7 @@ namespace {
  * IWRR scheduler.
  */
 template <class C>
-class IWRRScheduler : public Scheduler<C> {
+class IWRRScheduler : public RRScheduler<C> {
  public:
   std::shared_ptr<C> peekAgain(std::function<double(const C&)> ) override {
     // not using this now
@@ -35,7 +37,6 @@ class IWRRScheduler : public Scheduler<C> {
   }
 
   void add(double weight, std::shared_ptr<C> entry) override {
-    curr_weights_.emplace(entry, weight);
     weights_.emplace(entry, weight);
   }
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -728,7 +728,7 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
     }
 
     if (use_iwrr_) {
-      scheduler.edf_ = std::make_unique<IWRRScheduler<const Host>>();
+      scheduler.edf_ = std::make_unique<WRSQScheduler<const Host>>();
     } else {
       scheduler.edf_ = std::make_unique<EdfScheduler<const Host>>();
     }

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -17,6 +17,7 @@
 #include "common/runtime/runtime_protos.h"
 #include "common/upstream/edf_scheduler.h"
 #include "common/upstream/iwrr_scheduler.h"
+#include "common/upstream/wrsq_scheduler.h"
 
 namespace Envoy {
 namespace Upstream {

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_benchmark_test",
     "envoy_cc_benchmark_binary",
+    "envoy_cc_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_library",
@@ -106,6 +107,25 @@ envoy_cc_test(
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_benchmark_binary(
+    name = "iwrr_benchmark",
+    srcs = ["iwrr_benchmark.cc"],
+    external_deps = [
+        "benchmark",
+    ],
+    deps = [
+        "//source/common/upstream:edf_scheduler_lib"
+    ],
+)
+
+envoy_cc_binary(
+    name = "iwrr_scheduler_verify",
+    srcs = ["iwrr_scheduler_verify.cc"],
+    deps = [
+        "//source/common/upstream:edf_scheduler_lib"
     ],
 )
 

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -117,7 +117,8 @@ envoy_cc_benchmark_binary(
         "benchmark",
     ],
     deps = [
-        "//source/common/upstream:edf_scheduler_lib"
+        "//source/common/upstream:edf_scheduler_lib",
+        "//source/common/common:random_generator_lib",
     ],
 )
 
@@ -125,7 +126,8 @@ envoy_cc_binary(
     name = "iwrr_scheduler_verify",
     srcs = ["iwrr_scheduler_verify.cc"],
     deps = [
-        "//source/common/upstream:edf_scheduler_lib"
+        "//source/common/upstream:edf_scheduler_lib",
+        "//source/common/common:random_generator_lib",
     ],
 )
 
@@ -316,6 +318,8 @@ envoy_cc_test(
     deps = [
         ":utility_lib",
         "//source/common/network:utility_lib",
+        "//source/common/upstream:edf_scheduler_lib",
+        "//source/common/common:random_generator_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/upstream:load_balancer_lib",
         "//source/common/upstream:upstream_includes",

--- a/test/common/upstream/iwrr_benchmark.cc
+++ b/test/common/upstream/iwrr_benchmark.cc
@@ -31,7 +31,8 @@ public:
     double weight;
   };
 
-  static std::vector<ObjInfo> setupUniqueWeights(Scheduler<uint32_t>& sched, size_t num_objs, ::benchmark::State& state) {
+  static std::vector<ObjInfo> setupUniqueWeights(
+      RRScheduler<uint32_t>& sched, size_t num_objs, ::benchmark::State& state) {
     std::vector<ObjInfo> info;
 
     state.PauseTiming();
@@ -53,10 +54,10 @@ public:
     return info;
   }
 
-  static void pickTest(Scheduler<uint32_t>& sched,
+  static void pickTest(RRScheduler<uint32_t>& sched,
                        size_t num_objs,
                        ::benchmark::State& state,
-                       std::function<std::vector<ObjInfo>(Scheduler<uint32_t>&)> setup) {
+                       std::function<std::vector<ObjInfo>(RRScheduler<uint32_t>&)> setup) {
 
     std::vector<ObjInfo> obj_info;
     // Track number of times something's been picked.
@@ -73,19 +74,6 @@ public:
 
       pick_counts[*p]++;
     }
-
-#if 0
-    size_t pick_sum = std::accumulate(pick_counts.begin(), pick_counts.end(), 0);
-    size_t weight_sum = 0;
-    for (uint32_t i = 0; i < obj_info.size(); ++i) {
-      weight_sum += obj_info[i].weight;
-    }
-
-    for (size_t c = 0; c < pick_counts.size(); ++c) {
-      std::cout << "obj=" << c << ", select_pct=" << 100 * static_cast<double>(pick_counts[c]) / pick_sum
-                << ", expected_pct=" << 100 * obj_info[c].weight / weight_sum << std::endl;
-    }
-#endif
   }
 };
 
@@ -106,7 +94,7 @@ void BM_UniqueWeightPickIWRR(::benchmark::State& state) {
   IWRRScheduler<uint32_t> iwrr;
   const size_t num_objs = state.range(0);
 
-  SchedulerTester::pickTest(iwrr, num_objs, state, [num_objs, &state](Scheduler<uint32_t>& sched) {
+  SchedulerTester::pickTest(iwrr, num_objs, state, [num_objs, &state](RRScheduler<uint32_t>& sched) {
     return SchedulerTester::setupUniqueWeights(sched, num_objs, state);
   });
 }
@@ -128,7 +116,7 @@ void BM_UniqueWeightPickEdf(::benchmark::State& state) {
   EdfScheduler<uint32_t> edf;
   const size_t num_objs = state.range(0);
 
-  SchedulerTester::pickTest(edf, num_objs, state, [num_objs, &state](Scheduler<uint32_t>& sched) {
+  SchedulerTester::pickTest(edf, num_objs, state, [num_objs, &state](RRScheduler<uint32_t>& sched) {
     return SchedulerTester::setupUniqueWeights(sched, num_objs, state);
   });
 }

--- a/test/common/upstream/iwrr_benchmark.cc
+++ b/test/common/upstream/iwrr_benchmark.cc
@@ -1,0 +1,146 @@
+// Usage: bazel run //test/common/upstream:iwrr_benchmark
+
+#include <algorithm>
+#include <memory>
+#include <iostream>
+
+#include "common/upstream/edf_scheduler.h"
+#include "common/upstream/iwrr_scheduler.h"
+
+#include "test/benchmark/main.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Upstream {
+namespace {
+
+/**
+ * This is meant to be a quick hack, not an actual patch.
+ */
+class SchedulerTester {
+public:
+  SchedulerTester() {
+  }
+
+  // For simplicity, the objects being selected are just uints. The vectors returned by the setup
+  // functions returns the objects to prevent expiry.
+
+  struct ObjInfo {
+    std::shared_ptr<uint32_t> val;
+    double weight;
+  };
+
+  static std::vector<ObjInfo> setupUniqueWeights(Scheduler<uint32_t>& sched, size_t num_objs, ::benchmark::State& state) {
+    std::vector<ObjInfo> info;
+
+    state.PauseTiming();
+    for (uint32_t i = 0; i < num_objs; ++i) {
+      ObjInfo oi;
+      oi.val = std::make_shared<uint32_t>(i),
+      oi.weight = static_cast<double>(i + 1),
+
+      info.emplace_back(oi);
+    } 
+
+    std::random_shuffle(info.begin(), info.end());
+    state.ResumeTiming();
+
+    for (auto& oi : info) {
+      sched.add(oi.weight, oi.val);
+    }
+
+    return info;
+  }
+
+  static void pickTest(Scheduler<uint32_t>& sched,
+                       size_t num_objs,
+                       ::benchmark::State& state,
+                       std::function<std::vector<ObjInfo>(Scheduler<uint32_t>&)> setup) {
+
+    std::vector<ObjInfo> obj_info;
+    // Track number of times something's been picked.
+    std::vector<size_t> pick_counts(num_objs, 0);
+
+    for (auto _ : state) { // NOLINT: Silences warning about dead store
+      if (obj_info.empty()){
+        obj_info = setup(sched);
+      }
+
+      auto p = sched.pickAndAdd([&obj_info](const auto& i) {
+        return obj_info[i].weight;
+      });
+
+      pick_counts[*p]++;
+    }
+
+#if 0
+    size_t pick_sum = std::accumulate(pick_counts.begin(), pick_counts.end(), 0);
+    size_t weight_sum = 0;
+    for (uint32_t i = 0; i < obj_info.size(); ++i) {
+      weight_sum += obj_info[i].weight;
+    }
+
+    for (size_t c = 0; c < pick_counts.size(); ++c) {
+      std::cout << "obj=" << c << ", select_pct=" << 100 * static_cast<double>(pick_counts[c]) / pick_sum
+                << ", expected_pct=" << 100 * obj_info[c].weight / weight_sum << std::endl;
+    }
+#endif
+  }
+};
+
+// -------------------------------------------------------------------------------------------------
+
+void BM_UniqueWeightAddIWRR(::benchmark::State& state) {
+  IWRRScheduler<uint32_t> iwrr;
+  const size_t num_objs = state.range(0);
+  for (auto _ : state) { // NOLINT: Silences warning about dead store
+    SchedulerTester::setupUniqueWeights(iwrr, num_objs, state);
+  }
+}
+BENCHMARK(BM_UniqueWeightAddIWRR)
+  ->Unit(::benchmark::kMicrosecond)
+  ->RangeMultiplier(2)->Range(1<<5, 1<<16);
+
+void BM_UniqueWeightPickIWRR(::benchmark::State& state) {
+  IWRRScheduler<uint32_t> iwrr;
+  const size_t num_objs = state.range(0);
+
+  SchedulerTester::pickTest(iwrr, num_objs, state, [num_objs, &state](Scheduler<uint32_t>& sched) {
+    return SchedulerTester::setupUniqueWeights(sched, num_objs, state);
+  });
+}
+BENCHMARK(BM_UniqueWeightPickIWRR)
+  ->RangeMultiplier(2)->Range(1<<5, 1<<16);
+
+void BM_UniqueWeightAddEdf(::benchmark::State& state) {
+  EdfScheduler<uint32_t> edf;
+  const size_t num_objs = state.range(0);
+  for (auto _ : state) { // NOLINT: Silences warning about dead store
+    SchedulerTester::setupUniqueWeights(edf, num_objs, state);
+  }
+}
+BENCHMARK(BM_UniqueWeightAddEdf)
+  ->Unit(::benchmark::kMicrosecond)
+  ->RangeMultiplier(2)->Range(1<<5, 1<<16);
+
+void BM_UniqueWeightPickEdf(::benchmark::State& state) {
+  EdfScheduler<uint32_t> edf;
+  const size_t num_objs = state.range(0);
+
+  SchedulerTester::pickTest(edf, num_objs, state, [num_objs, &state](Scheduler<uint32_t>& sched) {
+    return SchedulerTester::setupUniqueWeights(sched, num_objs, state);
+  });
+}
+BENCHMARK(BM_UniqueWeightPickEdf)
+  ->RangeMultiplier(2)->Range(1<<5, 1<<16);
+
+// benchmarks
+// - setup times
+// - picks
+// - peeks
+
+} // namespace
+} // namespace Upstream
+} // namespace Envoy
+

--- a/test/common/upstream/iwrr_benchmark.cc
+++ b/test/common/upstream/iwrr_benchmark.cc
@@ -6,6 +6,7 @@
 
 #include "common/upstream/edf_scheduler.h"
 #include "common/upstream/iwrr_scheduler.h"
+#include "common/upstream/wrsq_scheduler.h"
 
 #include "test/benchmark/main.h"
 
@@ -101,6 +102,8 @@ void BM_UniqueWeightPickIWRR(::benchmark::State& state) {
 BENCHMARK(BM_UniqueWeightPickIWRR)
   ->RangeMultiplier(2)->Range(1<<5, 1<<16);
 
+// ==================
+
 void BM_UniqueWeightAddEdf(::benchmark::State& state) {
   EdfScheduler<uint32_t> edf;
   const size_t num_objs = state.range(0);
@@ -121,6 +124,30 @@ void BM_UniqueWeightPickEdf(::benchmark::State& state) {
   });
 }
 BENCHMARK(BM_UniqueWeightPickEdf)
+  ->RangeMultiplier(2)->Range(1<<5, 1<<16);
+
+// -----------------------<<
+
+void BM_UniqueWeightAddWRSQ(::benchmark::State& state) {
+  WRSQScheduler<uint32_t> wrsq;
+  const size_t num_objs = state.range(0);
+  for (auto _ : state) { // NOLINT: Silences warning about dead store
+    SchedulerTester::setupUniqueWeights(wrsq, num_objs, state);
+  }
+}
+BENCHMARK(BM_UniqueWeightAddWRSQ)
+  ->Unit(::benchmark::kMicrosecond)
+  ->RangeMultiplier(2)->Range(1<<5, 1<<16);
+
+void BM_UniqueWeightPickWRSQ(::benchmark::State& state) {
+  WRSQScheduler<uint32_t> wrsq;
+  const size_t num_objs = state.range(0);
+
+  SchedulerTester::pickTest(wrsq, num_objs, state, [num_objs, &state](RRScheduler<uint32_t>& sched) {
+    return SchedulerTester::setupUniqueWeights(sched, num_objs, state);
+  });
+}
+BENCHMARK(BM_UniqueWeightPickWRSQ)
   ->RangeMultiplier(2)->Range(1<<5, 1<<16);
 
 // benchmarks

--- a/test/common/upstream/iwrr_scheduler_verify.cc
+++ b/test/common/upstream/iwrr_scheduler_verify.cc
@@ -1,0 +1,115 @@
+#include <algorithm>
+#include <memory>
+#include <iostream>
+
+#include "common/upstream/edf_scheduler.h"
+#include "common/upstream/iwrr_scheduler.h"
+
+using namespace Envoy::Upstream;
+
+/**
+ * Hacking together some quick checks.
+ */
+
+size_t syncCheck(Scheduler<uint32_t>& sched1, Scheduler<uint32_t>& sched2) {
+  size_t collisions = 0;
+
+  std::vector<std::pair<double, std::shared_ptr<uint32_t>>> inputs;
+  for (uint32_t i = 1; i < 1000; ++i) {
+    inputs.emplace_back(i, std::make_shared<uint32_t>(i));
+  }
+
+  std::random_shuffle(inputs.begin(), inputs.end());
+
+  for (const auto& p : inputs) {
+    sched1.add(p.first, p.second);
+  }
+
+  std::random_shuffle(inputs.begin(), inputs.end());
+
+  for (const auto& p : inputs) {
+    sched2.add(p.first, p.second);
+  }
+
+  auto fn = [](const auto& obj) { return static_cast<double>(obj); };
+  for (int i = 0; i < 10000; ++i) {
+    auto r1 = sched1.pickAndAdd(fn);
+    auto r2 = sched2.pickAndAdd(fn);
+    if (*r1 == *r2) {
+      ++collisions;
+    }
+  }
+
+  return collisions;
+}
+
+void selectionCounts(Scheduler<uint32_t>& sched) {
+  std::cout << "diff between observed and expected % (1.0 means 1%)\n";
+
+  // Try 16 objects for sane plots.
+  constexpr size_t num_objs = 16;
+
+  constexpr size_t n = 10000;
+
+  std::vector<std::pair<double, std::shared_ptr<uint32_t>>> inputs;
+  for (uint32_t i = 1; i <= num_objs; ++i) {
+    inputs.emplace_back(static_cast<double>(i), std::make_shared<uint32_t>(i));
+  }
+
+  std::random_shuffle(inputs.begin(), inputs.end());
+  for (const auto& p : inputs) {
+    sched.add(p.first, p.second);
+  }
+
+
+  std::unordered_map<uint32_t, size_t> selection_counts;
+  auto fn = [](const auto& obj) { return static_cast<double>(obj); };
+  for (size_t i = 0; i < n; ++i) {
+    auto p = sched.pickAndAdd(fn);
+    selection_counts[*p]++;
+  }
+
+  double weight_sum = 0;
+  for (const auto& i : inputs) {
+    weight_sum += i.first;
+  }
+
+  for (const auto& p : selection_counts) {
+    const double observed_pct = 100 * static_cast<double>(p.second) / n;
+    const double expected_pct = 100 * static_cast<double>(p.first) / weight_sum;
+    std::cout << (expected_pct - observed_pct) << std::endl;
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+void syncCheckIWRR() {
+  IWRRScheduler<uint32_t> iwrr1, iwrr2;
+  std::cout << "IWRR collisions: " << syncCheck(iwrr1, iwrr2) << std::endl;
+}
+
+void syncCheckEDF() {
+  EdfScheduler<uint32_t> edf1, edf2;
+  std::cout << "EDF collisions: " << syncCheck(edf1, edf2) << std::endl;
+}
+
+void countsIWRR() {
+  std::cout << "---\nIWRR selections\n--\n";
+  IWRRScheduler<uint32_t> iwrr;
+  selectionCounts(iwrr);
+}
+
+void countsEDF() {
+  std::cout << "---\nEDF selections\n--\n";
+  EdfScheduler<uint32_t> edf;
+  selectionCounts(edf);
+}
+
+int main() {
+  syncCheckEDF();
+  syncCheckIWRR();
+  countsEDF();
+  countsIWRR();
+
+  return 0;
+}

--- a/test/common/upstream/iwrr_scheduler_verify.cc
+++ b/test/common/upstream/iwrr_scheduler_verify.cc
@@ -4,6 +4,7 @@
 
 #include "common/upstream/edf_scheduler.h"
 #include "common/upstream/iwrr_scheduler.h"
+#include "common/upstream/wrsq_scheduler.h"
 
 using namespace Envoy::Upstream;
 
@@ -11,7 +12,7 @@ using namespace Envoy::Upstream;
  * Hacking together some quick checks.
  */
 
-size_t syncCheck(Scheduler<uint32_t>& sched1, Scheduler<uint32_t>& sched2) {
+size_t syncCheck(RRScheduler<uint32_t>& sched1, RRScheduler<uint32_t>& sched2) {
   size_t collisions = 0;
 
   std::vector<std::pair<double, std::shared_ptr<uint32_t>>> inputs;
@@ -43,7 +44,7 @@ size_t syncCheck(Scheduler<uint32_t>& sched1, Scheduler<uint32_t>& sched2) {
   return collisions;
 }
 
-void selectionCounts(Scheduler<uint32_t>& sched) {
+void selectionCounts(RRScheduler<uint32_t>& sched) {
   std::cout << "diff between observed and expected % (1.0 means 1%)\n";
 
   // Try 16 objects for sane plots.
@@ -83,6 +84,11 @@ void selectionCounts(Scheduler<uint32_t>& sched) {
 
 // -------------------------------------------------------------------------------------------------
 
+void syncCheckWRSQ() {
+  WRSQScheduler<uint32_t> wrsq1, wrsq2;
+  std::cout << "WRSQ collisions: " << syncCheck(wrsq1, wrsq2) << std::endl;
+}
+
 void syncCheckIWRR() {
   IWRRScheduler<uint32_t> iwrr1, iwrr2;
   std::cout << "IWRR collisions: " << syncCheck(iwrr1, iwrr2) << std::endl;
@@ -105,11 +111,19 @@ void countsEDF() {
   selectionCounts(edf);
 }
 
+void countsWRSQ() {
+  std::cout << "---\nWRSQ selections\n--\n";
+  WRSQScheduler<uint32_t> wrsq;
+  selectionCounts(wrsq);
+}
+
 int main() {
   syncCheckEDF();
   syncCheckIWRR();
+  syncCheckWRSQ();
   countsEDF();
   countsIWRR();
+  countsWRSQ();
 
   return 0;
 }

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -83,7 +83,7 @@ class WRRLoadBalancerTest : public ::testing::Test {
     return makePrioritySet(hosts);
   }
 
-  // Create a new RR load balancer using either an EDF or IWRR scheduler.
+  // is_iwrr means to use WRSQ now
   std::unique_ptr<RoundRobinLoadBalancer> makeRoundRobinLb(bool is_iwrr, PrioritySetImpl& priority_set) {
     return std::make_unique<RoundRobinLoadBalancer>(
         priority_set, nullptr, *stats_, runtime_, random_, common_config_, is_iwrr);
@@ -162,8 +162,9 @@ class WRRLoadBalancerTest : public ::testing::Test {
     const size_t num_rq = 1e4;
 
     std::vector<std::pair<size_t, double>> host_info{
-      {2, 100},
-      {2, 2000},
+      {1, 9030},
+      {1, 870},
+      {1, 100},
     };
 
     PrioritySetImpl priority_set = generatePrioritySetCustom(std::move(host_info));
@@ -221,15 +222,15 @@ class WRRLoadBalancerTest : public ::testing::Test {
   }
 };
 
-TEST_F(WRRLoadBalancerTest, ManyUniqueWeightsIWRR) {
-//  uniqueHostTest(true);
+TEST_F(WRRLoadBalancerTest, ManyUniqueWeightsWRSQ) {
+  //uniqueHostTest(true);
 }
 
 TEST_F(WRRLoadBalancerTest, ManyUniqueWeightsEDF) {
 //  uniqueHostTest(false);
 }
 
-TEST_F(WRRLoadBalancerTest, 1stPickIWRR) {
+TEST_F(WRRLoadBalancerTest, 1stPickWRSQ) {
 //  firstPickTest(true);
 }
 
@@ -237,12 +238,12 @@ TEST_F(WRRLoadBalancerTest, 1stPickEDF) {
 //  firstPickTest(false);
 }
 
-TEST_F(WRRLoadBalancerTest, BunchingTestIWRR) {
+TEST_F(WRRLoadBalancerTest, BunchingTestWRSQ) {
   bunchingTest(true);
 }
 
 TEST_F(WRRLoadBalancerTest, BunchingTestEDF) {
-  bunchingTest(false);
+//  bunchingTest(false);
 }
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This may be completely misguided, but I threw something together to compare an IWRR scheduler to EDF. In the patch, there's a benchmark and some throwaway test to compare any syncing behavior and selection probability differences. All of the tests are scenarios where each object in the scheduler has a unique weight, but this should be easy to change to satisfy any curiosities.

The EDF scheduler was turned into an interface and I implemented parts of it with IWRR. I benchmarked adding objects to each scheduler and the actual time it takes to perform a selection. The ranges in all benchmarks are the number of objects added to the schedulers:
```
Run on (24 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x12)
  L1 Instruction 32 KiB (x12)
  L2 Unified 512 KiB (x12)
  L3 Unified 16384 KiB (x4)
Load Average: 3.84, 2.74, 2.34
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
BM_UniqueWeightAddIWRR/32           1.26 us         1.26 us       564531
BM_UniqueWeightAddIWRR/64           2.24 us         2.23 us       327536
BM_UniqueWeightAddIWRR/128          4.07 us         4.06 us       186418
BM_UniqueWeightAddIWRR/256          8.30 us         8.22 us        94944
BM_UniqueWeightAddIWRR/512          15.8 us         15.8 us        47262
BM_UniqueWeightAddIWRR/1024         30.8 us         30.7 us        23951
BM_UniqueWeightAddIWRR/2048         61.1 us         60.6 us        12306
BM_UniqueWeightAddIWRR/4096          121 us          120 us         6109
BM_UniqueWeightAddIWRR/8192          243 us          242 us         2964
BM_UniqueWeightAddIWRR/16384         493 us          491 us         1476
BM_UniqueWeightAddIWRR/32768        1001 us          998 us          743
BM_UniqueWeightAddIWRR/65536        1925 us         1920 us          325
BM_UniqueWeightPickIWRR/32          21.1 ns         21.0 ns     33360546
BM_UniqueWeightPickIWRR/64          21.0 ns         20.9 ns     33361729
BM_UniqueWeightPickIWRR/128         20.9 ns         20.8 ns     33631291
BM_UniqueWeightPickIWRR/256         20.9 ns         20.8 ns     33710884
BM_UniqueWeightPickIWRR/512         20.7 ns         20.6 ns     33922177
BM_UniqueWeightPickIWRR/1024        20.4 ns         20.3 ns     34432897
BM_UniqueWeightPickIWRR/2048        20.6 ns         20.4 ns     34369365
BM_UniqueWeightPickIWRR/4096        21.1 ns         21.0 ns     33134134
BM_UniqueWeightPickIWRR/8192        20.8 ns         20.8 ns     33789884
BM_UniqueWeightPickIWRR/16384       21.5 ns         21.5 ns     33865091
BM_UniqueWeightPickIWRR/32768       21.6 ns         21.6 ns     32268061
BM_UniqueWeightPickIWRR/65536       22.3 ns         22.2 ns     30807780
BM_UniqueWeightAddEdf/32            2.07 us         2.06 us       393891
BM_UniqueWeightAddEdf/64            3.95 us         3.93 us       189932
BM_UniqueWeightAddEdf/128           7.28 us         7.25 us       103391
BM_UniqueWeightAddEdf/256           14.2 us         14.1 us        52543
BM_UniqueWeightAddEdf/512           28.1 us         27.9 us        26729
BM_UniqueWeightAddEdf/1024          57.1 us         56.8 us        10000
BM_UniqueWeightAddEdf/2048           112 us          111 us         7065
BM_UniqueWeightAddEdf/4096           236 us          235 us         3465
BM_UniqueWeightAddEdf/8192           457 us          456 us         1688
BM_UniqueWeightAddEdf/16384          907 us          904 us          829
BM_UniqueWeightAddEdf/32768         1871 us         1864 us          409
BM_UniqueWeightAddEdf/65536         4055 us         4036 us          187
BM_UniqueWeightPickEdf/32           67.3 ns         67.1 ns     10455114
BM_UniqueWeightPickEdf/64           70.0 ns         69.8 ns     10029050
BM_UniqueWeightPickEdf/128          76.0 ns         75.8 ns      9381319
BM_UniqueWeightPickEdf/256          81.4 ns         81.2 ns      8658490
BM_UniqueWeightPickEdf/512          87.5 ns         87.3 ns      8033924
BM_UniqueWeightPickEdf/1024         95.9 ns         95.7 ns      7271247
BM_UniqueWeightPickEdf/2048          106 ns          105 ns      6685158
BM_UniqueWeightPickEdf/4096          111 ns          111 ns      6228352
BM_UniqueWeightPickEdf/8192          126 ns          125 ns      5526998
BM_UniqueWeightPickEdf/16384         144 ns          144 ns      4826959
BM_UniqueWeightPickEdf/32768         153 ns          152 ns      4638594
BM_UniqueWeightPickEdf/65536         192 ns          192 ns      3920313
```

It's entirely possible I'm doing something wrong here, but IWRR's numbers are looking pretty good. ~2x faster than EDF for adds and the runtime complexity is O(1) for picks.
![image](https://user-images.githubusercontent.com/1109246/98498410-8d88e900-21fb-11eb-9989-b71a9fb24406.png)

![image](https://user-images.githubusercontent.com/1109246/98498457-a8f3f400-21fb-11eb-81e6-29fc241a5b31.png)


There's also a test that looks at syncing behavior, where we add objects with unique weights to two of the same schedulers and pick from them in lock-step. Any collisions are noted. The long and short of it is that EDF syncs and IWRR does not:
```
EDF collisions: 10000
IWRR collisions: 6
```

There were 10k iterations across 1k objects, so EDF is obviously syncing.

Then there was a sanity check to make sure the selection probabilities were not affected. There was no appreciable difference:
```
---
EDF selections
--
diff between observed and expected % (1.0 means 1%)
0.00529412
0.000588235
0.00588235
-0.00529412
-0.000588235
-0.00588235
-0.00117647
-0.00647059
-0.00176471
0.00294118
-0.00235294
0.00235294
-0.00294118
0.00176471
0.00647059
0.00117647
---
IWRR selections
--
diff between observed and expected % (1.0 means 1%)
0.0241176
-0.00235294
-0.0182353
0.00352941
-0.0176471
-0.00941176
0.0294118
-0.0141176
0.0347059
0.00294118
-0.0129412
-0.00470588
0.00823529
0.0188235
-0.0188235
-0.0235294
```